### PR TITLE
Read input from same line #25

### DIFF
--- a/src/functions.rs
+++ b/src/functions.rs
@@ -37,11 +37,13 @@ pub fn get_input(output: &str) -> Result<String, anyhow::Error> {
     let mut line = String::new();
     
     // Print out the passed value
-    println!("{} ", output);
+    println!("{}", output);
+    print!("> ");
+    io::stdout().flush()?;
 
     // Read input into the line variable and call the 
     // function to clean the input and return the result
-    std::io::stdin().read_line(&mut line).unwrap();
+    std::io::stdin().read_line(&mut line)?;
     clean_input(line)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,8 +131,8 @@ fn vault_unlock_stage(
     }
 
     // Return to main menu check
-    println!("[{}] Return to Main Menu", counter);
-    let input = functions::get_input(">")?;
+    //println!("[{}] Return to Main Menu", counter);
+    let input = functions::get_input(&format!("[{}] Return to Main Menu", counter)[..])?;
     if input == counter.to_string() || input.to_lowercase() == "q" 
         || input.to_lowercase() == "quit" {
             return Ok(())
@@ -225,10 +225,9 @@ fn vault_remove_stage(
         else {println!("[{}] {} - {}", counter, i.name, UNKNOWN);}
         counter += 1;
     }
-    println!("[{}] Return to Main Menu", counter);
 
     // Get input and confirmation for deletion
-    let input = functions::get_input(">")?;
+    let input = functions::get_input(&format!("[{}] Return to Main Menu", counter)[..])?;
 
     // Check for return to Main Menu
     if input == counter.to_string() || input.to_lowercase() == "q"


### PR DESCRIPTION
Fixes #25

Changes the read function to read from the same line. Will print the options and then accept input with `>`

Ex:
```
[1] Vault Name
[2] Return to menu
> *****
```